### PR TITLE
Update wood gross energy cost per kwh to use consumer.nz numbers

### DIFF
--- a/app/services/configuration/energy_costs_default.py
+++ b/app/services/configuration/energy_costs_default.py
@@ -23,30 +23,12 @@ energy-and-natural-resources/energy-statistics-and-modelling/
 energy-statistics/oil-statistics
 
 Wood pricing:
-
-Base this on:
-    • Price per cord: NZD $375
-    • Volume of a Cord = 128 cubic feet = 3.62m^3
-    • Density of dry pine = 480 kg/m^3
-    • Energy content of dry pine = 15 MJ / tonne
-        = 15E6 / 3.6 / 1E6 = 4.17 kWh / kg
-
-Exclude the following factor:
-    • Efficiency of modern wood stove = 70%
-We calculate the price per kWh of heat content in the wood and
-account for the efficiency of a modern wood stove separately.
-
-kWh per dollar = (
-    Volume of a Cord *
-    Density of dry pine *
-    Energy content of dry pine *
-    Efficiency of modern wood stove) / Price per cord
- = (3.62 * 480 * 4.17) / 375
- = 19.32 kWh per dollar
-
-Inverting this gives $0.052 per kWh of heat in the wood.
-
-This works out to $0.074 per kWh of heat output from a modern wood stove.
+    Base this on:
+        Buying firewood: how to get a hot deal - Consumer NZ
+        https://www.consumer.org.nz/articles/firewood
+        Price per m³ (cubic meter) of Pine, Gum, Macrocarpa, and Hot mix wood
+        Density for each type of wood and energy content based on 4.17 kWh/kg
+        Take a simple average of the cost per kWh for each type of wood.
 """
 
 from ...models.energy_plans import (
@@ -109,35 +91,37 @@ def get_default_lpg_plan():
 
 def get_default_wood_price():
     """
-    Return a default wood plan.
+    Base this on:
+        Buying firewood: how to get a hot deal - Consumer NZ
+        https://www.consumer.org.nz/articles/firewood
 
-    Wood price: $0.074 per kWh for a modern wood stove with 70% efficiency.
+        Price per m³ (cubic meter) of each type of wood:
 
-    This is based on:
-        • Price per cord: NZD $375
-        • Volume of a Cord = 128 cubic feet = 3.62m^3
-        • Density of dry pine = 480 kg/m^3
-        • Energy content of dry pine = 15 MJ / tonne = 15E6 / 3.6E6 = 4.17 kWh / kg
+        Pine (softwood): NZD $120/m³
+        Gum (hardwood): NZD $160/m³
+        Macrocarpa (medium-density wood): NZD $152/m³
+        Hot mix: NZD $140/m³
+        Densities and energy content for each type of wood:
 
-    Exclude the following factor:
-        • Efficiency of modern wood stove = 70%
-    We calculate the price per kWh of heat content in the wood and
-    account for the efficiency of a modern wood stove separately.
+        Density of pine (softwood): 480 kg/m³
+        Density of gum (hardwood): 700 kg/m³
+        Density of macrocarpa (medium-density wood): 540 kg/m³
+        Density of hot mix: 560 kg/m³
+        Energy content of dry wood: 4.17 kWh/kg
 
-    kWh per dollar = (
-        Volume of a Cord *
-        Density of dry pine *
-        Energy content of dry pine) / Price per cord
+        Exclude the following factor:
+        Efficiency of modern wood stove = 70%
 
-    = (3.62 * 480 * 4.17) / 375
-    = 19.32 kWh per dollar
+        Pine: 120/480/4.17 $/kWh = $0.05995 per kWh
+        Gum: 160/700/4.17 $/kWh = $0.05481 per kWh
+        Macrocarpa: 152/540/4.17 $/kWh = $0.0675 per kWh
+        Hot mix: 140/560/4.17 $/kWh = $0.05995 per kWh
 
-    Inverting this gives $0.052 per kWh of heat in the wood.
-    This works out to $0.074 per kWh of heat output from a modern wood stove.
+        Average: $0.06055 per kWh
     """
     return WoodPrice(
         name="Default Wood Price",
-        per_wood_kwh=0.052,
+        per_wood_kwh=0.061,
     )
 
 

--- a/app/services/configuration/energy_costs_default.py
+++ b/app/services/configuration/energy_costs_default.py
@@ -23,12 +23,19 @@ energy-and-natural-resources/energy-statistics-and-modelling/
 energy-statistics/oil-statistics
 
 Wood pricing:
-    Base this on:
-        Buying firewood: how to get a hot deal - Consumer NZ
-        https://www.consumer.org.nz/articles/firewood
-        Price per m³ (cubic meter) of Pine, Gum, Macrocarpa, and Hot mix wood
-        Density for each type of wood and energy content based on 4.17 kWh/kg
-        Take a simple average of the cost per kWh for each type of wood.
+    Figures justified by:
+
+        Typical price per m³ (cubic meter) from Consumer NZ:
+        $140 (hot mix price) and average of soft and
+        hardwood prices ($120 and $160 respectively).
+
+        Density for thrown volume and energy content from:
+        Bittermann, W., & Suvorov, M. (2012, May 29).
+        Quality standard for statistics on wood fuel
+        consumption of households (taking into account
+        the relative importance for the 20-20-20 goals):
+        Working Group 2: Methodology. Statistics Austria;
+        Statistical Office of the Republic of Slovenia.
 """
 
 from ...models.energy_plans import (
@@ -91,37 +98,33 @@ def get_default_lpg_plan():
 
 def get_default_wood_price():
     """
-    Base this on:
-        Buying firewood: how to get a hot deal - Consumer NZ
-        https://www.consumer.org.nz/articles/firewood
+    Figures justified by:
 
-        Price per m³ (cubic meter) of each type of wood:
+        Typical price per m³ (cubic meter) from Consumer NZ:
+        $140 (hot mix price) and average of soft and
+        hardwood prices ($120 and $160 respectively).
 
-        Pine (softwood): NZD $120/m³
-        Gum (hardwood): NZD $160/m³
-        Macrocarpa (medium-density wood): NZD $152/m³
-        Hot mix: NZD $140/m³
-        Densities and energy content for each type of wood:
+        Density for thrown volume and energy content from:
+        Bittermann, W., & Suvorov, M. (2012, May 29).
+        Quality standard for statistics on wood fuel
+        consumption of households (taking into account
+        the relative importance for the 20-20-20 goals):
+        Working Group 2: Methodology. Statistics Austria;
+        Statistical Office of the Republic of Slovenia.
 
-        Density of pine (softwood): 480 kg/m³
-        Density of gum (hardwood): 700 kg/m³
-        Density of macrocarpa (medium-density wood): 540 kg/m³
-        Density of hot mix: 560 kg/m³
-        Energy content of dry wood: 4.17 kWh/kg
-
-        Exclude the following factor:
-        Efficiency of modern wood stove = 70%
-
-        Pine: 120/480/4.17 $/kWh = $0.05995 per kWh
-        Gum: 160/700/4.17 $/kWh = $0.05481 per kWh
-        Macrocarpa: 152/540/4.17 $/kWh = $0.0675 per kWh
-        Hot mix: 140/560/4.17 $/kWh = $0.05995 per kWh
-
-        Average: $0.06055 per kWh
+        ($/m3)(m3/kg)(kg/MJ)(MJ/kWh) = ($/kWh)
     """
+    price_per_cubic_metre = 150
+    thrown_density_kg_per_m3 = 300
+    net_calorific_value_mj_per_kg = 16
+    conversion_factor_mj_per_kwh = 3.6
+
     return WoodPrice(
         name="Default Wood Price",
-        per_wood_kwh=0.061,
+        per_wood_kwh=price_per_cubic_metre
+        / thrown_density_kg_per_m3
+        / net_calorific_value_mj_per_kg
+        * conversion_factor_mj_per_kwh,
     )
 
 

--- a/app/services/configuration/energy_costs_default.py
+++ b/app/services/configuration/energy_costs_default.py
@@ -114,7 +114,7 @@ def get_default_wood_price():
 
         ($/m3)(m3/kg)(kg/MJ)(MJ/kWh) = ($/kWh)
     """
-    price_per_cubic_metre = 150
+    price_per_cubic_metre = 140
     thrown_density_kg_per_m3 = 300
     net_calorific_value_mj_per_kg = 16
     conversion_factor_mj_per_kwh = 3.6

--- a/app/services/configuration/energy_costs_default.py
+++ b/app/services/configuration/energy_costs_default.py
@@ -25,9 +25,9 @@ energy-statistics/oil-statistics
 Wood pricing:
     Figures justified by:
 
-        Typical price per m³ (cubic meter) from Consumer NZ:
-        $140 (hot mix price) and average of soft and
-        hardwood prices ($120 and $160 respectively).
+        Typical price per m³ from Consumer NZ:
+        NZ$140 (hot mix price) and average of soft and
+        hardwood prices (NZ$120 and NZ$160 respectively).
 
         Density for thrown volume and energy content from:
         Bittermann, W., & Suvorov, M. (2012, May 29).
@@ -100,9 +100,9 @@ def get_default_wood_price():
     """
     Figures justified by:
 
-        Typical price per m³ (cubic meter) from Consumer NZ:
-        $140 (hot mix price) and average of soft and
-        hardwood prices ($120 and $160 respectively).
+        Typical price per m³ from Consumer NZ:
+        NZ$140 (hot mix price) and average of soft and
+        hardwood prices (NZ$120 and NZ$160 respectively).
 
         Density for thrown volume and energy content from:
         Bittermann, W., & Suvorov, M. (2012, May 29).

--- a/tests/models/test_energy_plan.py
+++ b/tests/models/test_energy_plan.py
@@ -68,7 +68,7 @@ def test_get_energy_plan():
     assert plan.lpg_plan.per_lpg_kwh == 0.244
     assert plan.lpg_plan.daily_charge == 0.37782340862423
     assert plan.wood_price.name == "Default Wood Price"
-    assert plan.wood_price.per_wood_kwh == 0.061
+    assert plan.wood_price.per_wood_kwh == 0.1125
     assert plan.petrol_price.name == "Default Petrol Price"
     assert plan.petrol_price.per_petrol_litre == 2.78
     assert plan.diesel_price.name == "Default Diesel Price"

--- a/tests/models/test_energy_plan.py
+++ b/tests/models/test_energy_plan.py
@@ -4,6 +4,8 @@ Test the energy plan service
 
 import unittest
 
+from pytest import approx
+
 from app.constants import DAYS_IN_YEAR
 from app.models.energy_plans import ElectricityPlan
 from app.models.usage_profiles import YearlyFuelUsageProfile
@@ -68,7 +70,7 @@ def test_get_energy_plan():
     assert plan.lpg_plan.per_lpg_kwh == 0.244
     assert plan.lpg_plan.daily_charge == 0.37782340862423
     assert plan.wood_price.name == "Default Wood Price"
-    assert plan.wood_price.per_wood_kwh == 0.1125
+    assert plan.wood_price.per_wood_kwh == approx(0.105)
     assert plan.petrol_price.name == "Default Petrol Price"
     assert plan.petrol_price.per_petrol_litre == 2.78
     assert plan.diesel_price.name == "Default Diesel Price"

--- a/tests/models/test_energy_plan.py
+++ b/tests/models/test_energy_plan.py
@@ -68,7 +68,7 @@ def test_get_energy_plan():
     assert plan.lpg_plan.per_lpg_kwh == 0.244
     assert plan.lpg_plan.daily_charge == 0.37782340862423
     assert plan.wood_price.name == "Default Wood Price"
-    assert plan.wood_price.per_wood_kwh == 0.052
+    assert plan.wood_price.per_wood_kwh == 0.061
     assert plan.petrol_price.name == "Default Petrol Price"
     assert plan.petrol_price.per_petrol_litre == 2.78
     assert plan.diesel_price.name == "Default Diesel Price"


### PR DESCRIPTION
Taking an average of gross energy cost per kwh over 4 typical wood fuel types using consumer.nz numbers
Note that these costs refer to the wood energy content rather than the final heat delivered (which will be ~1/0.7 more expensive per kWh for a typical wood burner).